### PR TITLE
The bottom left or first rocket ship part image needs to be rotated 90 degrees clockwise

### DIFF
--- a/assets/css/core.css
+++ b/assets/css/core.css
@@ -285,7 +285,7 @@ ul span{
     clear: both;
     background-image: url(../img/00.png);
     background-size: cover;
-    transform:rotate(270deg);
+    transform:rotate(360deg);
     background-origin: content-box;
 }
 #top-left


### PR DESCRIPTION
As a website user, I want the first rocket ship part image in the bottom left to be rotated 90 degrees clockwise, so that it aligns correctly with the other parts and provides a visually coherent assembly guidance.