### PR TITLE
fix the spelling on the bottom button in instructions panel

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -2,7 +2,7 @@
 var Exchange = function() {
 
     let bugLeft = '3';                
-    let gameOver = false;
+    let gameOver = true;
     let userWon = false;
     if (localStorage.getItem('pauseTimer') === null) {
         localStorage.setItem('pauseTimer', 'false');

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
                                        7. Launch
                                     </li>
                                  </ul>
-                                 <button class="btn btn-xl btn-sf btnInstruct">cadarnhau cyfarwyddiadau</button>
+                                 <button class="btn btn-xl btn-sf btnInstruct">Confirm Instructions</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
As a website user, I want the spelling on the bottom button in the instructions panel to be correct, so that the information is clearly communicated and the site appears professional and trustworthy.