### PR TITLE
Sky rocket tile has a wrong orientation, left bottom tile should be rotated 90 degrees clockwise

### DIFF
--- a/assets/css/core.css
+++ b/assets/css/core.css
@@ -285,7 +285,7 @@ ul span{
     clear: both;
     background-image: url(../img/00.png);
     background-size: cover;
-    transform:rotate(270deg);
+    transform:rotate(360deg);
     background-origin: content-box;
 }
 #top-left


### PR DESCRIPTION
As a website user, I want the Sky rocket tile to have the correct orientation, specifically for the left bottom tile to be rotated 90 degrees clockwise, so that the visual display is accurate and aesthetically pleasing.