### PR TITLE
Napraw przycisk na samym dole na jezyk angielski

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -2,7 +2,7 @@
 var Exchange = function() {
 
     let bugLeft = '2';                
-    let gameOver = false;
+    let gameOver = true;
     let userWon = false;
     if (localStorage.getItem('pauseTimer') === null) {
         localStorage.setItem('pauseTimer', 'false');

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
                                        7. Launch
                                     </li>
                                  </ul>
-                                 <button class="btn btn-xl btn-sf btnInstruct">cadarnhau cyfarwyddiadau</button>
+                                 <button class="btn btn-xl btn-sf btnInstruct">Confirm Instructions</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Title: Fix the Language of the Bottom Button on the Website

User Story:
As an English-speaking user, I want the button at the bottom of the page to be labeled in English instead of Polish, so that I can understand and interact with it correctly.