### PR TITLE
set userwon variable to true

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -2,7 +2,7 @@
 var Exchange = function() {
 
     let bugLeft = '3';                
-    let gameOver = false;
+    let gameOver = true;
     let userWon = false;
     if (localStorage.getItem('pauseTimer') === null) {
         localStorage.setItem('pauseTimer', 'false');

--- a/index.html
+++ b/index.html
@@ -304,8 +304,9 @@
                     Exchange.newGamePopup();
                 }
                 
-                if(localStorage.getItem('targetTime') !== null && !Exchange.userWon)
+                if(localStorage.getItem('targetTime') !== null && !Exchange.userWon && Exchange.checkWinningConditions())
                 {
+                    Exchange.userWon = true;
                     Exchange.updateTimer();
                 }
 


### PR DESCRIPTION
User Story:
As a website game developer, I want the 'userWon' variable to appropriately reflect the game state as true when a user meets the winning conditions, so that the game accurately tracks and displays the victory to enhance user satisfaction and engagement.