### PR TITLE
spaceship pictures wrongly aligned, bottom left part has to be rotated 90 degrees to the right

### DIFF
--- a/assets/css/core.css
+++ b/assets/css/core.css
@@ -285,7 +285,7 @@ ul span{
     clear: both;
     background-image: url(../img/00.png);
     background-size: cover;
-    transform:rotate(270deg);
+    transform:rotate(360deg);
     background-origin: content-box;
 }
 #top-left

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -1,7 +1,7 @@
 
 var Exchange = function() {
 
-    let bugLeft = '3';                
+    let bugLeft = '2';                
     let gameOver = false;
     let userWon = false;
     if (localStorage.getItem('pauseTimer') === null) {


### PR DESCRIPTION
**User Story:**

**As a website visitor**, I want the spaceship pictures to be correctly aligned, specifically the bottom left part needs to be rotated 90 degrees to the right, so that I can view the images as intended and enjoy a visually coherent display.