### PR TITLE
rotate bottom left tile 90deg right of rocket blueprint (image)

### DIFF
--- a/assets/css/core.css
+++ b/assets/css/core.css
@@ -285,7 +285,7 @@ ul span{
     clear: both;
     background-image: url(../img/00.png);
     background-size: cover;
-    transform:rotate(270deg);
+    transform:rotate(360deg);
     background-origin: content-box;
 }
 #top-left

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -1,7 +1,7 @@
 
 var Exchange = function() {
 
-    let bugLeft = '3';                
+    let bugLeft = '2';                
     let gameOver = false;
     let userWon = false;
     if (localStorage.getItem('pauseTimer') === null) {


### PR DESCRIPTION
User Story:

As a website visitor using the interactive rocket blueprint feature, I want the bottom left tile to rotate correctly by 90 degrees to the right, so that the blueprint displays accurately and enhances my understanding of the rocket design.